### PR TITLE
⏳ [gha] disable homebrew feature that does not work in github runners

### DIFF
--- a/.github/workflows/brew-formula-test.yml
+++ b/.github/workflows/brew-formula-test.yml
@@ -19,6 +19,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    env:
+      HOMEBREW_NO_SANDBOX_LINUX: 1
+
     permissions:
       contents: read
 


### PR DESCRIPTION
<!-- PR_BODY_DONE_START -->
## Done

- ⏳ [gha] disable homebrew feature that does not work in github runners

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)
