### PR TITLE
🤵 [gha] skip sig/pem during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,8 +84,14 @@ jobs:
         run: |
           set -euo pipefail
           # Keyless signing via GitHub OIDC - no long-lived secrets to rotate.
-          # The --bundle file contains the signature and certificate; verify
-          # downstream with `cosign verify-blob --bundle "${BUNDLE}.bundle"`.
+          # The --bundle file embeds the signature, certificate, and Rekor
+          # entry; verify downstream with the identity/issuer flags, e.g.:
+          #   cosign verify-blob \
+          #     --bundle homebrew-chicks-${TAG}.tar.gz.bundle \
+          #     --certificate-identity-regexp \
+          #       "https://github.com/chicks-net/homebrew-chicks/.github/workflows/release.yml@refs/tags/${TAG}" \
+          #     --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+          #     homebrew-chicks-${TAG}.tar.gz
           cosign sign-blob --yes "${BUNDLE}" \
             --bundle "${BUNDLE}.bundle"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,9 +84,9 @@ jobs:
         run: |
           set -euo pipefail
           # Keyless signing via GitHub OIDC - no long-lived secrets to rotate.
+          # The --bundle file contains the signature and certificate; verify
+          # downstream with `cosign verify-blob --bundle "${BUNDLE}.bundle"`.
           cosign sign-blob --yes "${BUNDLE}" \
-            --output-signature "${BUNDLE}.sig" \
-            --output-certificate "${BUNDLE}.pem" \
             --bundle "${BUNDLE}.bundle"
 
       - name: Upload signed assets to release
@@ -99,8 +99,6 @@ jobs:
           gh release upload "${TAG}" \
             "${BUNDLE}" \
             checksums.txt \
-            "${BUNDLE}.sig" \
-            "${BUNDLE}.pem" \
             "${BUNDLE}.bundle" \
             "${BUNDLE}.sbom.json" \
             --clobber

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ brew bundle --file=$(brew --prefix)/share/chicks-desktop/Brewfile
 Each tagged release (e.g. `v0.5`) ships a metadata-only asset bundle
 (`homebrew-chicks-<tag>.tar.gz` containing the formula files, `Brewfile`, and
 this README), a `checksums.txt` file, a cosign keyless signature
-(`.sig` / `.pem` / `.bundle`), an SBOM (`.sbom.json`), and an SLSA provenance
+(`.bundle`), an SBOM (`.sbom.json`), and an SLSA provenance
 attestation (`multiple.intoto.jsonl`).
 
 ### Verify the asset signature with cosign

--- a/justfile
+++ b/justfile
@@ -422,7 +422,7 @@ setup-chicks-desktop:
 # Verify a release's cosign signature and SLSA provenance (defaults to latest)
 # Usage: just verify-release [v0.5]
 [group('Release')]
-verify-release TAG="$(gh release view --json tagName -q .tagName)":
+verify-release TAG=`gh release view --json tagName -q .tagName`:
     #!/usr/bin/env bash
     set -euo pipefail
 
@@ -475,7 +475,12 @@ verify-release TAG="$(gh release view --json tagName -q .tagName)":
     echo "{{GREEN}}Verifying checksums.txt...{{NORMAL}}"
     # checksums.txt only covers the bundle; regenerate and compare.
     EXPECTED="$(grep -E " ${BUNDLE}\$" checksums.txt | awk '{print $1}')"
-    ACTUAL="$(sha256sum "${BUNDLE}" | awk '{print $1}')"
+    # sha256sum is GNU coreutils (absent on macOS); fall back to shasum -a 256
+    if command -v sha256sum >/dev/null 2>&1; then
+        ACTUAL="$(sha256sum "${BUNDLE}" | awk '{print $1}')"
+    else
+        ACTUAL="$(shasum -a 256 "${BUNDLE}" | awk '{print $1}')"
+    fi
     if [[ "$EXPECTED" != "$ACTUAL" ]]; then
         echo "{{RED}}Checksum mismatch: expected $EXPECTED, got $ACTUAL{{NORMAL}}"
         exit 1

--- a/justfile
+++ b/justfile
@@ -419,6 +419,70 @@ setup-chicks-desktop:
 	fi
 	exec "$PKGSHARE/bin/chicks-desktop-setup"
 
+# Verify a release's cosign signature and SLSA provenance (defaults to latest)
+# Usage: just verify-release [v0.5]
+[group('Release')]
+verify-release TAG="$(gh release view --json tagName -q .tagName)":
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    TAG="{{TAG}}"
+    REPO="chicks-net/homebrew-chicks"
+    BUNDLE="homebrew-chicks-${TAG}.tar.gz"
+    BASE="https://github.com/${REPO}/releases/download/${TAG}"
+
+    echo "{{BLUE}}Verifying release ${TAG} for ${REPO}...{{NORMAL}}"
+
+    # Check required tools
+    for tool in cosign slsa-verifier curl; do
+        if ! command -v "$tool" >/dev/null 2>&1; then
+            echo "{{RED}}Error: '$tool' not found. Install with: brew install $tool{{NORMAL}}"
+            exit 1
+        fi
+    done
+
+    WORKDIR="$(mktemp -d)"
+    trap 'rm -rf "$WORKDIR"' EXIT
+    cd "$WORKDIR"
+
+    echo "{{GREEN}}Downloading assets for ${TAG}...{{NORMAL}}"
+    # Use --fail so curl exits non-zero on 4xx/5xx (e.g. 404) instead of
+    # silently saving the GitHub "Not Found" error page, which later makes
+    # cosign choke with "invalid character 'N' looking for beginning of value".
+    for ASSET in "${BUNDLE}" "${BUNDLE}.bundle" "multiple.intoto.jsonl" "checksums.txt"; do
+        if ! curl --fail --location --output "${ASSET}" "${BASE}/${ASSET}"; then
+            echo "{{RED}}Error: failed to download ${BASE}/${ASSET} (HTTP error)."
+            echo "       Release ${TAG} may have no signed assets attached."
+            echo "       Check: gh release view ${TAG} --json assets -q '.assets[].name'{{NORMAL}}"
+            exit 1
+        fi
+    done
+
+    echo "{{GREEN}}Verifying cosign keyless signature...{{NORMAL}}"
+    cosign verify-blob \
+        --bundle "${BUNDLE}.bundle" \
+        --certificate-identity-regexp "https://github.com/${REPO}/.github/workflows/release.yml@refs/tags/${TAG}" \
+        --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+        "${BUNDLE}"
+
+    echo "{{GREEN}}Verifying SLSA build provenance...{{NORMAL}}"
+    slsa-verifier verify-artifact \
+        --provenance-path multiple.intoto.jsonl \
+        --source-uri "github.com/${REPO}" \
+        --source-tag "${TAG}" \
+        "${BUNDLE}"
+
+    echo "{{GREEN}}Verifying checksums.txt...{{NORMAL}}"
+    # checksums.txt only covers the bundle; regenerate and compare.
+    EXPECTED="$(grep -E " ${BUNDLE}\$" checksums.txt | awk '{print $1}')"
+    ACTUAL="$(sha256sum "${BUNDLE}" | awk '{print $1}')"
+    if [[ "$EXPECTED" != "$ACTUAL" ]]; then
+        echo "{{RED}}Checksum mismatch: expected $EXPECTED, got $ACTUAL{{NORMAL}}"
+        exit 1
+    fi
+
+    echo "{{GREEN}}All signature and provenance checks passed for ${TAG}!{{NORMAL}}"
+
 # Validate the Brewfile syntax
 [group('Formula')]
 validate-brewfile:


### PR DESCRIPTION
<!-- PR_BODY_DONE_START -->
## Done

- 🤵 [gha] skip sig/pem during release
- 📝 [release] address copilot review: complete verify comment, drop .sig/.pem from README
- add verify-release just recipe
- handle missing sha256sum on base macos

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)



